### PR TITLE
Make health scale with stats

### DIFF
--- a/Content.Shared/Mobs/Components/MobThresholdsComponent.cs
+++ b/Content.Shared/Mobs/Components/MobThresholdsComponent.cs
@@ -1,6 +1,7 @@
 ﻿using Content.Shared.FixedPoint;
 using Content.Shared.Mobs.Systems;
 using Robust.Shared.GameStates;
+using Robust.Shared.Serialization;
 
 namespace Content.Shared.Mobs.Components;
 
@@ -8,18 +9,38 @@ namespace Content.Shared.Mobs.Components;
 [Access(typeof(MobThresholdSystem))]
 public sealed class MobThresholdsComponent : Component
 {
-    [DataField("thresholds", required:true), AutoNetworkedField(true)]
+    [DataField("thresholds", required:true)]
     public SortedDictionary<FixedPoint2, MobState> Thresholds = new();
 
-    [DataField("triggersAlerts"), AutoNetworkedField]
+    [DataField("triggersAlerts")]
     public bool TriggersAlerts = true;
 
-    [DataField("currentThresholdState"), AutoNetworkedField]
+    [DataField("currentThresholdState")]
     public MobState CurrentThresholdState;
 
     /// <summary>
     /// Whether or not this entity can be revived out of a dead state.
     /// </summary>
-    [DataField("allowRevives"), AutoNetworkedField]
+    [DataField("allowRevives")]
     public bool AllowRevives;
+}
+
+[Serializable, NetSerializable]
+public sealed class MobThresholdsComponentState : ComponentState
+{
+    public Dictionary<FixedPoint2, MobState> UnsortedThresholds;
+
+    public bool TriggersAlerts;
+
+    public MobState CurrentThresholdState;
+
+    public bool AllowRevives;
+
+    public MobThresholdsComponentState(Dictionary<FixedPoint2, MobState> unsortedThresholds, bool triggersAlerts, MobState currentThresholdState, bool allowRevives)
+    {
+        UnsortedThresholds = unsortedThresholds;
+        TriggersAlerts = triggersAlerts;
+        CurrentThresholdState = currentThresholdState;
+        AllowRevives = allowRevives;
+    }
 }

--- a/Content.Shared/Mobs/Systems/MobThresholdSystem.cs
+++ b/Content.Shared/Mobs/Systems/MobThresholdSystem.cs
@@ -4,6 +4,7 @@ using Content.Shared.Alert;
 using Content.Shared.Damage;
 using Content.Shared.FixedPoint;
 using Content.Shared.Mobs.Components;
+using Robust.Shared.GameStates;
 
 namespace Content.Shared.Mobs.Systems;
 
@@ -14,10 +15,36 @@ public sealed class MobThresholdSystem : EntitySystem
 
     public override void Initialize()
     {
+        SubscribeLocalEvent<MobThresholdsComponent, ComponentGetState>(OnGetState);
+        SubscribeLocalEvent<MobThresholdsComponent, ComponentHandleState>(OnHandleState);
+
         SubscribeLocalEvent<MobThresholdsComponent, ComponentShutdown>(MobThresholdShutdown);
         SubscribeLocalEvent<MobThresholdsComponent, ComponentStartup>(MobThresholdStartup);
         SubscribeLocalEvent<MobThresholdsComponent, DamageChangedEvent>(OnDamaged);
         SubscribeLocalEvent<MobThresholdsComponent, UpdateMobStateEvent>(OnUpdateMobState);
+    }
+
+    private void OnGetState(EntityUid uid, MobThresholdsComponent component, ref ComponentGetState args)
+    {
+        var thresholds = new Dictionary<FixedPoint2, MobState>();
+        foreach (var (key, value) in component.Thresholds)
+        {
+            thresholds.Add(key, value);
+        }
+        args.State = new MobThresholdsComponentState(thresholds,
+            component.TriggersAlerts,
+            component.CurrentThresholdState,
+            component.AllowRevives);
+    }
+
+    private void OnHandleState(EntityUid uid, MobThresholdsComponent component, ref ComponentHandleState args)
+    {
+        if (args.Current is not MobThresholdsComponentState state)
+            return;
+        component.Thresholds = new SortedDictionary<FixedPoint2, MobState>(state.UnsortedThresholds);
+        component.TriggersAlerts = state.TriggersAlerts;
+        component.CurrentThresholdState = state.CurrentThresholdState;
+        component.AllowRevives = state.AllowRevives;
     }
 
     #region Public API
@@ -222,7 +249,16 @@ public sealed class MobThresholdSystem : EntitySystem
         if (!Resolve(target, ref threshold))
             return;
 
+        // create a duplicate dictionary so we don't modify while enumerating.
+        var thresholds = new Dictionary<FixedPoint2, MobState>(threshold.Thresholds);
+        foreach (var (damageThreshold, state) in thresholds)
+        {
+            if (state != mobState)
+                continue;
+            threshold.Thresholds.Remove(damageThreshold);
+        }
         threshold.Thresholds[damage] = mobState;
+        Dirty(threshold);
         VerifyThresholds(target, threshold);
     }
 

--- a/Content.Shared/_ArcheCrawl/Stats/Components/StatScaledHealthComponent.cs
+++ b/Content.Shared/_ArcheCrawl/Stats/Components/StatScaledHealthComponent.cs
@@ -8,7 +8,7 @@ namespace Content.Shared._ArcheCrawl.Stats.Components;
 /// threshold of an entity based on a stat
 /// </summary>
 [RegisterComponent]
-public sealed class StatVariedThresholdComponent : Component
+public sealed class StatScaledHealthComponent : Component
 {
     /// <summary>
     /// The base value of the threshold when stat equals 0.

--- a/Content.Shared/_ArcheCrawl/Stats/Components/StatVariedThresholdComponent.cs
+++ b/Content.Shared/_ArcheCrawl/Stats/Components/StatVariedThresholdComponent.cs
@@ -1,0 +1,37 @@
+﻿using Content.Shared.Mobs;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
+
+namespace Content.Shared._ArcheCrawl.Stats.Components;
+
+/// <summary>
+/// This is used for scaling the death
+/// threshold of an entity based on a stat
+/// </summary>
+[RegisterComponent]
+public sealed class StatVariedThresholdComponent : Component
+{
+    /// <summary>
+    /// The base value of the threshold when stat equals 0.
+    /// </summary>
+    [DataField("baseThreshold")]
+    public float BaseThreshold = 20f;
+
+    /// <summary>
+    /// The increase in the threshold per stat
+    /// </summary>
+    [DataField("thresholdPerStat")]
+    public float ThresholdPerStat = 2f;
+
+    /// <summary>
+    /// The stat that scales the threshold
+    /// </summary>
+    [DataField("scalingStat", customTypeSerializer: typeof(PrototypeIdSerializer<StatPrototype>))]
+    public string ScalingStat = "Vigor";
+
+    /// <summary>
+    /// The threshold for this state is being scaled.
+    /// Idk why you wouldn't want this to be Dead but here ya go.
+    /// </summary>
+    [DataField("targetState")]
+    public MobState TargetState = MobState.Dead;
+}

--- a/Content.Shared/_ArcheCrawl/Stats/SharedStatsSystem.Scaling.cs
+++ b/Content.Shared/_ArcheCrawl/Stats/SharedStatsSystem.Scaling.cs
@@ -9,10 +9,10 @@ public abstract partial class SharedStatsSystem
 
     public void InitializeScaling()
     {
-        SubscribeLocalEvent<StatVariedThresholdComponent, StatChangedEvent>(OnStatVariedDeathThresholdChanged);
+        SubscribeLocalEvent<StatScaledHealthComponent, StatChangedEvent>(OnStatVariedDeathThresholdChanged);
     }
 
-    private void OnStatVariedDeathThresholdChanged(EntityUid uid, StatVariedThresholdComponent component, ref StatChangedEvent args)
+    private void OnStatVariedDeathThresholdChanged(EntityUid uid, StatScaledHealthComponent component, ref StatChangedEvent args)
     {
         if (args.Stat.ID != component.ScalingStat)
             return;

--- a/Content.Shared/_ArcheCrawl/Stats/SharedStatsSystem.Scaling.cs
+++ b/Content.Shared/_ArcheCrawl/Stats/SharedStatsSystem.Scaling.cs
@@ -1,0 +1,23 @@
+﻿using Content.Shared._ArcheCrawl.Stats.Components;
+using Content.Shared.Mobs.Systems;
+
+namespace Content.Shared._ArcheCrawl.Stats;
+
+public abstract partial class SharedStatsSystem
+{
+    [Dependency] private readonly MobThresholdSystem _mobThreshold = default!;
+
+    public void InitializeScaling()
+    {
+        SubscribeLocalEvent<StatVariedThresholdComponent, StatChangedEvent>(OnStatVariedDeathThresholdChanged);
+    }
+
+    private void OnStatVariedDeathThresholdChanged(EntityUid uid, StatVariedThresholdComponent component, ref StatChangedEvent args)
+    {
+        if (args.Stat.ID != component.ScalingStat)
+            return;
+
+        var val = MathF.Round(component.BaseThreshold + args.NewValue * component.ThresholdPerStat);
+        _mobThreshold.SetMobStateThreshold(uid, val, component.TargetState);
+    }
+}

--- a/Content.Shared/_ArcheCrawl/Stats/SharedStatsSystem.cs
+++ b/Content.Shared/_ArcheCrawl/Stats/SharedStatsSystem.cs
@@ -17,6 +17,8 @@ public abstract partial class SharedStatsSystem : EntitySystem
     /// <inheritdoc/>
     public override void Initialize()
     {
+        InitializeScaling();
+
         SubscribeLocalEvent<StatsComponent, MapInitEvent>(OnMapInit);
 
         _sawmill = Logger.GetSawmill("stat");
@@ -24,7 +26,11 @@ public abstract partial class SharedStatsSystem : EntitySystem
 
     private void OnMapInit(EntityUid uid, StatsComponent component, MapInitEvent args)
     {
-        component.Stats = new (component.InitialStats);
+        foreach (var (key, val) in component.InitialStats)
+        {
+            component.Stats[key] = default;
+            SetStatValue(uid, key, val, component);
+        }
         Dirty(component);
     }
 

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -11,7 +11,7 @@
       Dexterity: 10
       Vigor: 10
       Intelligence: 10
-  - type: StatVariedThreshold
+  - type: StatScaledHealth
   - type: LagCompensation
   - type: RangedDamageSound
     soundGroups:

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -7,10 +7,11 @@
   components:
   - type: Stats
     initialStats:
-      Strength: 5
-      Dexterity: 5
-      Vigor: 5
-      Intelligence: 5
+      Strength: 10
+      Dexterity: 10
+      Vigor: 10
+      Intelligence: 10
+  - type: StatVariedThreshold
   - type: LagCompensation
   - type: RangedDamageSound
     soundGroups:
@@ -206,8 +207,7 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      100: Critical
-      200: Dead
+      100: Dead
   - type: Destructible
     thresholds:
       - trigger:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
adds a simple stats scaling for health.
Humanoids have 20 health + 2 health per vigor

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- add: Adds stat-based health scaling.
